### PR TITLE
fixed killall the bg process of QEMU when gdb quit

### DIFF
--- a/code/asm/rule.mk
+++ b/code/asm/rule.mk
@@ -18,6 +18,7 @@ debug: all
 	@echo "-------------------------------------------------------"
 	@${QEMU} ${QFLAGS} -kernel ${EXEC}.elf -s -S &
 	@${GDB} ${EXEC}.elf -q -x ${GDBINIT}
+	@killall -e ${QEMU}
 
 .PHONY : code
 code: all


### PR DESCRIPTION
解决 二次调试是 QEMU后台运行，无法正常调试的问题 