### PR TITLE
fix: 02 management os.ld about data section

### DIFF
--- a/code/os/02-memanagement/os.ld
+++ b/code/os/02-memanagement/os.ld
@@ -104,8 +104,15 @@ SECTIONS
 		 * current location becomes aligned on 4096-byte boundary.
 		 * This is because our paging system's resolution is 4,096 bytes.
 		 */
-		. = ALIGN(4096);
-		PROVIDE(_data_start = .);
+		/* . = ALIGN(4096);
+		PROVIDE(_data_start = .); */
+		/**! BUG Here is a question, if `. = ALIGN (4096)` in the front, 
+		 * ! it will cause the position in the kernel to get DATA_START directly changed to BSS_START, 
+		 * ! while BSS_START and DATA_END are equal, which means that DATA_START = DATA_END, 
+		 * ! resulting in a direct DATA segment of 0
+         */
+        PROVIDE(_data_start = .);
+        . = ALIGN(4096);
 		/*
 		 * sdata and data are essentially the same thing. We do not need
 		 * to distinguish sdata from data.


### PR DESCRIPTION
## About os.ld file data section error?

I was recently rewriting a simple os. When it comes to page table management, I find that the **start address and end address of the data segment are the same, but when I use `readelf` to read, I find that the result is normal, so there is a serious conflict**.

![image](https://github.com/plctlab/riscv-operating-system-mooc/assets/96290967/2e8bd0a2-a5d0-460d-aea3-a758f7f875b4)

The result of the picture above shows the result of the unchanged code, and you can see that **the start address and end address of the DATA segment are the same**.

```c
.data : {
	. = ALIGN(4096);
	PROVIDE(_data_start = .);
```

I know this is because of memory alignment, but **if this happens in the kernel, I don't know if it will have serious consequences later**, because I haven't deployed OS to the development board yet, so I can't test it.

After the following modifications, **the results displayed in readelf are consistent with those obtained in the kernel.**

```c
.data : {
	/* . = ALIGN(4096);
	PROVIDE(_data_start = .); */
	/**! BUG Here is a question, if `. = ALIGN (4096)` in the front, 
	 * ! it will cause the position in the kernel to get DATA_START directly changed to BSS_START, 
	 * ! while BSS_START and DATA_END are equal, which means that DATA_START = DATA_END, 
	 * ! resulting in a direct DATA segment of 0
         */
        PROVIDE(_data_start = .);
        . = ALIGN(4096);
```

![image](https://github.com/plctlab/riscv-operating-system-mooc/assets/96290967/40137f47-bc23-4135-967a-aedc3b078478)
