### PR TITLE
Correct inconsistent behavior of GNU assembler .align

### DIFF
--- a/code/os/00-bootstrap/start.S
+++ b/code/os/00-bootstrap/start.S
@@ -28,7 +28,7 @@ park:
 
 	# In the standard RISC-V calling convention, the stack pointer sp
 	# is always 16-byte aligned.
-.align 16
+.balign 16
 stacks:
 	.skip	STACK_SIZE * MAXNUM_CPU # allocate space for all the harts stacks
 

--- a/code/os/01-helloRVOS/start.S
+++ b/code/os/01-helloRVOS/start.S
@@ -28,7 +28,7 @@ park:
 
 	# In the standard RISC-V calling convention, the stack pointer sp
 	# is always 16-byte aligned.
-.align 16
+.balign 16
 stacks:
 	.skip	STACK_SIZE * MAXNUM_CPU # allocate space for all the harts stacks
 

--- a/code/os/02-memanagement/start.S
+++ b/code/os/02-memanagement/start.S
@@ -38,7 +38,7 @@ park:
 
 	# In the standard RISC-V calling convention, the stack pointer sp
 	# is always 16-byte aligned.
-.align 16
+.balign 16
 stacks:
 	.skip	STACK_SIZE * MAXNUM_CPU # allocate space for all the harts stacks
 

--- a/code/os/03-contextswitch/entry.S
+++ b/code/os/03-contextswitch/entry.S
@@ -92,7 +92,7 @@
 # void switch_to(struct context *next);
 # a0: pointer to the context of the next task
 .globl switch_to
-.align 4
+.balign 4
 switch_to:
 	csrrw	t6, mscratch, t6	# swap t6 and mscratch
 	beqz	t6, 1f			# Note: the first time switch_to() is

--- a/code/os/03-contextswitch/start.S
+++ b/code/os/03-contextswitch/start.S
@@ -38,7 +38,7 @@ park:
 
 	# In the standard RISC-V calling convention, the stack pointer sp
 	# is always 16-byte aligned.
-.align 16
+.balign 16
 stacks:
 	.skip	STACK_SIZE * MAXNUM_CPU # allocate space for all the harts stacks
 

--- a/code/os/04-multitask/entry.S
+++ b/code/os/04-multitask/entry.S
@@ -92,7 +92,7 @@
 # void switch_to(struct context *next);
 # a0: pointer to the context of the next task
 .globl switch_to
-.align 4
+.balign 4
 switch_to:
 	csrrw	t6, mscratch, t6	# swap t6 and mscratch
 	beqz	t6, 1f			# Note: the first time switch_to() is

--- a/code/os/04-multitask/start.S
+++ b/code/os/04-multitask/start.S
@@ -38,7 +38,7 @@ park:
 
 	# In the standard RISC-V calling convention, the stack pointer sp
 	# is always 16-byte aligned.
-.align 16
+.balign 16
 stacks:
 	.skip	STACK_SIZE * MAXNUM_CPU # allocate space for all the harts stacks
 

--- a/code/os/05-traps/entry.S
+++ b/code/os/05-traps/entry.S
@@ -92,7 +92,7 @@
 # interrupts and exceptions while in machine mode come here.
 .globl trap_vector
 # the trap vector base address must always be aligned on a 4-byte boundary
-.align 4
+.balign 4
 trap_vector:
 	# save context(registers).
 	csrrw	t6, mscratch, t6	# swap t6 and mscratch
@@ -125,7 +125,7 @@ trap_vector:
 # void switch_to(struct context *next);
 # a0: pointer to the context of the next task
 .globl switch_to
-.align 4
+.balign 4
 switch_to:
 	csrrw	t6, mscratch, t6	# swap t6 and mscratch
 	beqz	t6, 1f			# Note: the first time switch_to() is

--- a/code/os/05-traps/start.S
+++ b/code/os/05-traps/start.S
@@ -38,7 +38,7 @@ park:
 
 	# In the standard RISC-V calling convention, the stack pointer sp
 	# is always 16-byte aligned.
-.align 16
+.balign 16
 stacks:
 	.skip	STACK_SIZE * MAXNUM_CPU # allocate space for all the harts stacks
 

--- a/code/os/06-interrupts/entry.S
+++ b/code/os/06-interrupts/entry.S
@@ -92,7 +92,7 @@
 # interrupts and exceptions while in machine mode come here.
 .globl trap_vector
 # the trap vector base address must always be aligned on a 4-byte boundary
-.align 4
+.balign 4
 trap_vector:
 	# save context(registers).
 	csrrw	t6, mscratch, t6	# swap t6 and mscratch
@@ -125,7 +125,7 @@ trap_vector:
 # void switch_to(struct context *next);
 # a0: pointer to the context of the next task
 .globl switch_to
-.align 4
+.balign 4
 switch_to:
 	csrrw	t6, mscratch, t6	# swap t6 and mscratch
 	beqz	t6, 1f			# Note: the first time switch_to() is

--- a/code/os/06-interrupts/start.S
+++ b/code/os/06-interrupts/start.S
@@ -38,7 +38,7 @@ park:
 
 	# In the standard RISC-V calling convention, the stack pointer sp
 	# is always 16-byte aligned.
-.align 16
+.balign 16
 stacks:
 	.skip	STACK_SIZE * MAXNUM_CPU # allocate space for all the harts stacks
 

--- a/code/os/07-hwtimer/entry.S
+++ b/code/os/07-hwtimer/entry.S
@@ -92,7 +92,7 @@
 # interrupts and exceptions while in machine mode come here.
 .globl trap_vector
 # the trap vector base address must always be aligned on a 4-byte boundary
-.align 4
+.balign 4
 trap_vector:
 	# save context(registers).
 	csrrw	t6, mscratch, t6	# swap t6 and mscratch
@@ -125,7 +125,7 @@ trap_vector:
 # void switch_to(struct context *next);
 # a0: pointer to the context of the next task
 .globl switch_to
-.align 4
+.balign 4
 switch_to:
 	csrrw	t6, mscratch, t6	# swap t6 and mscratch
 	beqz	t6, 1f			# Note: the first time switch_to() is

--- a/code/os/07-hwtimer/start.S
+++ b/code/os/07-hwtimer/start.S
@@ -38,7 +38,7 @@ park:
 
 	# In the standard RISC-V calling convention, the stack pointer sp
 	# is always 16-byte aligned.
-.align 16
+.balign 16
 stacks:
 	.skip	STACK_SIZE * MAXNUM_CPU # allocate space for all the harts stacks
 

--- a/code/os/08-preemptive/entry.S
+++ b/code/os/08-preemptive/entry.S
@@ -92,7 +92,7 @@
 # interrupts and exceptions while in machine mode come here.
 .globl trap_vector
 # the trap vector base address must always be aligned on a 4-byte boundary
-.align 4
+.balign 4
 trap_vector:
 	# save context(registers).
 	csrrw	t6, mscratch, t6	# swap t6 and mscratch
@@ -129,7 +129,7 @@ trap_vector:
 # void switch_to(struct context *next);
 # a0: pointer to the context of the next task
 .globl switch_to
-.align 4
+.balign 4
 switch_to:
 	# switch mscratch to point to the context of the next task
 	csrw	mscratch, a0

--- a/code/os/08-preemptive/start.S
+++ b/code/os/08-preemptive/start.S
@@ -48,7 +48,7 @@ park:
 
 	# In the standard RISC-V calling convention, the stack pointer sp
 	# is always 16-byte aligned.
-.align 16
+.balign 16
 stacks:
 	.skip	STACK_SIZE * MAXNUM_CPU # allocate space for all the harts stacks
 

--- a/code/os/09-lock/entry.S
+++ b/code/os/09-lock/entry.S
@@ -92,7 +92,7 @@
 # interrupts and exceptions while in machine mode come here.
 .globl trap_vector
 # the trap vector base address must always be aligned on a 4-byte boundary
-.align 4
+.balign 4
 trap_vector:
 	# save context(registers).
 	csrrw	t6, mscratch, t6	# swap t6 and mscratch
@@ -129,7 +129,7 @@ trap_vector:
 # void switch_to(struct context *next);
 # a0: pointer to the context of the next task
 .globl switch_to
-.align 4
+.balign 4
 switch_to:
 	# switch mscratch to point to the context of the next task
 	csrw	mscratch, a0

--- a/code/os/09-lock/start.S
+++ b/code/os/09-lock/start.S
@@ -48,7 +48,7 @@ park:
 
 	# In the standard RISC-V calling convention, the stack pointer sp
 	# is always 16-byte aligned.
-.align 16
+.balign 16
 stacks:
 	.skip	STACK_SIZE * MAXNUM_CPU # allocate space for all the harts stacks
 

--- a/code/os/10-swtimer/entry.S
+++ b/code/os/10-swtimer/entry.S
@@ -92,7 +92,7 @@
 # interrupts and exceptions while in machine mode come here.
 .globl trap_vector
 # the trap vector base address must always be aligned on a 4-byte boundary
-.align 4
+.balign 4
 trap_vector:
 	# save context(registers).
 	csrrw	t6, mscratch, t6	# swap t6 and mscratch
@@ -129,7 +129,7 @@ trap_vector:
 # void switch_to(struct context *next);
 # a0: pointer to the context of the next task
 .globl switch_to
-.align 4
+.balign 4
 switch_to:
 	# switch mscratch to point to the context of the next task
 	csrw	mscratch, a0

--- a/code/os/10-swtimer/start.S
+++ b/code/os/10-swtimer/start.S
@@ -48,7 +48,7 @@ park:
 
 	# In the standard RISC-V calling convention, the stack pointer sp
 	# is always 16-byte aligned.
-.align 16
+.balign 16
 stacks:
 	.skip	STACK_SIZE * MAXNUM_CPU # allocate space for all the harts stacks
 

--- a/code/os/11-syscall/entry.S
+++ b/code/os/11-syscall/entry.S
@@ -92,7 +92,7 @@
 # interrupts and exceptions while in machine mode come here.
 .globl trap_vector
 # the trap vector base address must always be aligned on a 4-byte boundary
-.align 4
+.balign 4
 trap_vector:
 	# save context(registers).
 	csrrw	t6, mscratch, t6	# swap t6 and mscratch
@@ -130,7 +130,7 @@ trap_vector:
 # void switch_to(struct context *next);
 # a0: pointer to the context of the next task
 .globl switch_to
-.align 4
+.balign 4
 switch_to:
 	# switch mscratch to point to the context of the next task
 	csrw	mscratch, a0

--- a/code/os/11-syscall/start.S
+++ b/code/os/11-syscall/start.S
@@ -75,7 +75,7 @@ park:
 
 	# In the standard RISC-V calling convention, the stack pointer sp
 	# is always 16-byte aligned.
-.align 16
+.balign 16
 stacks:
 	.skip	STACK_SIZE * MAXNUM_CPU # allocate space for all the harts stacks
 


### PR DESCRIPTION
The GNU assembler directive `.align` has different behavior depending on the platform. From the gas manual ([https://ftp.gnu.org/old-gnu/Manuals/gas-2.9.1/html_chapter/as_7.html](url)):

>  The way the required alignment is specified varies from system to system. For the a29k, hppa, m68k, m88k, w65, sparc, and Hitachi SH, and i386 using ELF format, the first expression is the alignment request in bytes. For example \`.align 8' advances the location counter until it is a multiple of 8. If the location counter is already a multiple of 8, no change is needed.
For other systems, including the i386 using a.out format, it is the number of low-order zero bits the location counter must have after advancement. For example \`.align 3' advances the location counter until it a multiple of 8. If the location counter is already a multiple of 8, no change is needed.
This inconsistency is due to the different behaviors of the various native assemblers for these systems which GAS must emulate. GAS also provides .balign and .p2align directives, described later, which have a consistent behavior across all architectures (but are specific to GAS). 

From my testing, RISC-V uses the method described in the second paragraph, so `.align 16` means align to a 64KiB boundary. Thus, to ensure 16-byte alignment we could use either `.align 4` or the arguably more-clear `.balign 16`. 

This has a significant effect on the size of the generated binary.

Before:
![before0](https://github.com/plctlab/riscv-operating-system-mooc/assets/99624125/6778d96a-8f9b-41f0-85db-094ce633cc74)
![before11](https://github.com/plctlab/riscv-operating-system-mooc/assets/99624125/1369d29e-88bc-45b1-bdc6-831ce8e772dc)

After:
![after0](https://github.com/plctlab/riscv-operating-system-mooc/assets/99624125/9041aa8b-cea8-4203-9950-0e6e8b2ef795)
![after11](https://github.com/plctlab/riscv-operating-system-mooc/assets/99624125/d13b8694-38b0-4e96-a72f-43774f9f0440)
